### PR TITLE
Add Codecov integration to GitHub Actions workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -159,13 +159,12 @@ jobs:
         retention-days: 14
 
     # Upload to Codecov
-    - name: Upload to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./TestResults/coverage.cobertura.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
+    - name: Upload coverage reports to Codecov
+    uses: codecov/codecov-action@v5
+    with:
+      fail_ci_if_error: true
+      files: ./TestResults/coverage.cobertura.xml
+      token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     needs: generate-report

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -158,6 +158,15 @@ jobs:
         path: coveragereport
         retention-days: 14
 
+    # Upload to Codecov
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./TestResults/coverage.cobertura.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: true
+
   publish:
     needs: generate-report
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -160,11 +160,11 @@ jobs:
 
     # Upload to Codecov
     - name: Upload coverage reports to Codecov
-    uses: codecov/codecov-action@v5
-    with:
-      fail_ci_if_error: true
-      files: ./TestResults/coverage.cobertura.xml
-      token: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v5
+      with:
+        fail_ci_if_error: true
+        files: ./TestResults/coverage.cobertura.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     needs: generate-report

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # Beacon
 
 [![.NET](https://github.com/erinnmclaughlin/Beacon/actions/workflows/dotnet.yml/badge.svg)](https://github.com/erinnmclaughlin/Beacon/actions/workflows/dotnet.yml)
+[![codecov](https://codecov.io/gh/erinnmclaughlin/Beacon/branch/main/graph/badge.svg)](https://codecov.io/gh/erinnmclaughlin/Beacon)
 
 ## Getting Started
 


### PR DESCRIPTION
Add a code coverage badge to the readme file.

* Modify `.github/workflows/dotnet.yml` to include a step to upload the coverage report to Codecov using the `codecov/codecov-action` GitHub Action.
* Add the Codecov badge URL to the `readme.md` file to display the code coverage badge.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/erinnmclaughlin/Beacon/pull/9?shareId=e93a4a0a-e734-4a46-827b-7824e42eb6d3).